### PR TITLE
Fix WebPack dev server.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Use our [starter script](https://www.npmjs.com/package/rangle-starter), with
 * `npm install`: install npm dependencies specified in package.json as well as typings specified in tsd.json (typings will be put into *typings* folder which is also git ignored).
 * `postinstall`: runs automatically after `npm install` and triggers a `npm run build` to provide a build directory to `npm start` by default
 
-* `npm run dev`: will start webpack's development server (with live reloading) on [http://localhost:8080](http://localhost:8080). Note that in this case the bundle will be generated in memory and your bundle in *dist* might get out of sync.
+* `npm run dev`: will start webpack's development server (with live reloading) on [http://localhost:3000](http://localhost:3000). Note that in this case the bundle will be generated in memory and your bundle in *dist* might get out of sync.
 * `npm start`: starts a production server serving the *dist* directory on [http://localhost:3000](http://localhost:3000)
 
 * `npm run build`: bundle all of the application including js/css/html files, with index.html generated according to a template specified in *index.html* (Everything will be put into *dist* folder).

--- a/package.json
+++ b/package.json
@@ -80,6 +80,8 @@
     "tslint-loader": "^1.0.2",
     "typescript": "^1.7.3",
     "url-loader": "^0.5.6",
-    "webpack": "^1.12.9"
+    "webpack": "^1.12.9",
+    "webpack-dev-middleware": "^1.4.0",
+    "webpack-hot-middleware": "^2.6.0"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,17 @@ const path = require("path");
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
+const baseAppEntries = [
+  './src/index.ts',
+];
+
+const devAppEntries = [
+  'webpack-hot-middleware/client?reload=true',
+];
+
+const appEntries = baseAppEntries
+  .concat(process.env.NODE_ENV === 'development' ? devAppEntries : []);
+
 const basePlugins = [
   new webpack.DefinePlugin({
     __DEV__: process.env.NODE_ENV !== 'production',
@@ -17,7 +28,9 @@ const basePlugins = [
   })
 ];
 
-const devPlugins = [];
+const devPlugins = [
+  new webpack.HotModuleReplacementPlugin(),
+];
 
 const prodPlugins = [
   new webpack.optimize.UglifyJsPlugin({
@@ -35,7 +48,7 @@ const plugins = basePlugins
 module.exports = {
 
   entry: {
-    app: './src/index.ts',
+    app: appEntries,
     vendor: [
       'es6-shim',
       'angular2/bundles/angular2-polyfills',
@@ -83,7 +96,7 @@ module.exports = {
       { test: /\.woff2/, loader: 'url' },
       { test: /\.ttf/, loader: 'url' },
     ],
-    noParse: [ /zone\.js\/dist\/.+/, /angular2\/bundles\/.+/ ]
+    noParse: [/zone\.js\/dist\/.+/, /angular2\/bundles\/.+/]
   }
-    
+
 }


### PR DESCRIPTION
Live reloading was not working.

- Added npm modules for webpack hot module replacement.
- Modified webpack.config.js based on settings found in [typescript-react-redux-starter](https://github.com/rangle/typescript-react-redux-starter/blob/master/webpack.config.js).
- Changed readme.md to say that `npm run dev` runs on port 3000 instead of 8080.