### PR TITLE
chore: deprecate properties, use inputs.

### DIFF
--- a/src/components/counter/counter.ts
+++ b/src/components/counter/counter.ts
@@ -2,9 +2,9 @@
 import {Component, View} from 'angular2/core';
 @Component({
   selector: 'counter',
-  properties: [
+  inputs: [
     'counter',
-    'increment',
+    'increment', 
     'decrement',
     'incrementIfOdd',
     'incrementAsync'

--- a/src/components/counter/counter.ts
+++ b/src/components/counter/counter.ts
@@ -4,7 +4,7 @@ import {Component, View} from 'angular2/core';
   selector: 'counter',
   inputs: [
     'counter',
-    'increment', 
+    'increment',
     'decrement',
     'incrementIfOdd',
     'incrementAsync'


### PR DESCRIPTION
As of this date, the Angular 2 docs on ComponentDecorator have not
marked `properties` as deprecated. However, based on @winkerVSbecks
observations, `inputs` appears to be favoured.

Docs:
https://angular.io/docs/ts/latest/api/core/ComponentMetadata-class.html