### PR TITLE
Add redux tests

### DIFF
--- a/src/actions/counter.test.ts
+++ b/src/actions/counter.test.ts
@@ -1,0 +1,61 @@
+import {mockStore} from '../tests.helpers';
+import {INCREMENT_COUNTER, DECREMENT_COUNTER} from './counter';
+import * as CounterActions from './counter';
+
+describe('counter action creators', () => {
+
+  it('increment should create INCREMENT_COUNTER action', () => {
+    chai.expect(CounterActions.increment())
+      .to.deep.equal({
+        type: INCREMENT_COUNTER
+      });
+  });
+
+  it('decrement should create DECREMENT_COUNTER action', () => {
+    chai.expect(CounterActions.decrement())
+      .to.deep.equal({
+        type: DECREMENT_COUNTER
+      });
+  });
+
+  it('incrementIfOdd should dispatch INCREMENT_COUNTER if counter is odd', (done) => {
+
+    const expectedAction = { type: INCREMENT_COUNTER };
+
+    const store = mockStore({
+      getState: () => {
+        return { 
+          counter: 1 
+        }
+      },
+      dispatch: (action) => {
+        chai.expect(action)
+          .to.deep.equal(expectedAction);
+
+        done();
+      }
+    });
+    
+    store.dispatch(CounterActions.incrementIfOdd());
+  });
+
+  it('incrementAsync should dispatch INCREMENT_COUNTER after given delay', (done) => {
+    const expectedAction = { type: INCREMENT_COUNTER };
+
+    const store = mockStore({
+      getState: () => {
+        return { 
+          counter: 0 
+        }
+      },
+      dispatch: (action) => {
+        chai.expect(action)
+          .to.deep.equal(expectedAction);
+
+        done();
+      }
+    });
+
+    store.dispatch(CounterActions.incrementAsync(100));
+  });
+});

--- a/src/reducers/counter.test.ts
+++ b/src/reducers/counter.test.ts
@@ -1,0 +1,29 @@
+import { INCREMENT_COUNTER, DECREMENT_COUNTER } from '../actions/counter';
+import counter from './counter'; 
+
+describe('counter reducers', () => {
+  it('should handle initial state', () => {
+    chai.expect(
+      counter(undefined, {})  
+    )
+    .to.equal(0)
+  });
+
+  it('should handle INCREMENT_COUNTER', () => {
+    chai.expect(
+      counter(0, {
+        type: INCREMENT_COUNTER
+      })  
+    )
+    .to.equal(1)
+  });
+
+  it('should handle DECREMENT_COUNTER', () => {
+    chai.expect(
+      counter(1, {
+        type: DECREMENT_COUNTER
+      })  
+    )
+    .to.equal(0)
+  });
+});

--- a/src/tests.helpers.ts
+++ b/src/tests.helpers.ts
@@ -1,0 +1,17 @@
+import {applyMiddleware, compose, createStore} from 'redux';
+import reducer from './reducers/index';
+const thunk = require('redux-thunk');
+
+const middlewares = [thunk];
+
+export function mockStore({ getState, dispatch }) {
+  function createStore() {
+    return { getState, dispatch };
+  }
+
+  const finalCreateStore = applyMiddleware(
+    ...middlewares
+  )(createStore);
+
+  return finalCreateStore();
+}


### PR DESCRIPTION
These tests are supposed to complement the redux testing section in ngCourse2:
https://github.com/rangle/ngCourse2/pull/86

I am not sure if `mockStore` (got it from blue-j) is bullet proof but it works.