### PR TITLE
Only load production .ts files in webpack build

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -32,7 +32,7 @@ module.exports = function (config) {
       },
       module: {
         loaders: [
-          loaders.ts
+          loaders.tsTest
         ],
         postLoaders: [
           loaders.istanbulInstrumenter

--- a/src/store/configure-store.ts
+++ b/src/store/configure-store.ts
@@ -1,12 +1,12 @@
 ///<reference path="./dev-types.d.ts"/>
 
 import {createStore, applyMiddleware, compose} from 'redux';
-import { fromJS } from 'immutable';
+import {fromJS} from 'immutable';
+import ReduxThunk from 'redux-thunk';
 import logger from './configure-logger';
 import promiseMiddleware from '../middleware/promise-middleware';
 import reducer from '../reducers/index';
 const persistState = require('redux-localstorage');
-const thunk = require('redux-thunk').default;
 
 const storageConfig = {
   key: 'angular2-redux-seed',
@@ -20,7 +20,7 @@ const storageConfig = {
 };
 
 function _getMiddleware() {
-  let middleware = [promiseMiddleware, thunk];
+  let middleware = [promiseMiddleware, ReduxThunk];
 
   if (__DEV__) {
     middleware = [...middleware, logger];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,6 +52,7 @@ module.exports = {
       'angular2/http',
       'redux',
       'redux-thunk',
+      'redux-localstorage',
       'ng2-redux',
       'redux-logger'
     ]

--- a/webpack/loaders.js
+++ b/webpack/loaders.js
@@ -1,28 +1,33 @@
+'use strict';
+
 exports.tslint = {
   test: /\.ts$/,
-  loader: 'tslint'
-};
-
-exports.istanbulInstrumenter = {
-  test: /\.ts$/,
-  loader: 'istanbul-instrumenter',
-  exclude: /(node_modules\/|\.test\.ts$|tests\.\w+\.ts$)/
-};
-
-exports.ts = {
-  test: /\.ts$/,
-  loader: 'ts-loader',
+  loader: 'tslint',
   exclude: /node_modules/
 };
 
+exports.tsTest = loadTs('ts', true);
+exports.istanbulInstrumenter = loadTs('istanbul-instrumenter');
+exports.ts = loadTs();
+
+function loadTs (loader, inTest) {
+  return {
+    test: /\.ts$/,
+    loader: loader || 'ts',
+    exclude: inTest ? /node_modules/ : /(node_modules\/|\.test\.ts$|tests\.\w+\.ts$)/
+  };
+}
+
 exports.html = {
   test: /\.html$/,
-  loader: 'raw'
+  loader: 'raw',
+  exclude: /node_modules/
 };
 
 exports.css = {
   test: /\.css$/,
-  loader: 'to-string!css!postcss'
+  loader: 'to-string!css!postcss',
+  exclude: /node_modules/
 };
 
 exports.svg = makeUrlLoader(/\.svg$/);
@@ -34,6 +39,7 @@ exports.ttf = makeUrlLoader(/\.ttf$/);
 function makeUrlLoader (pattern) {
   return {
     test: pattern,
-    loader: 'url'
+    loader: 'url',
+    exclude: /node_modules/
   };
 }


### PR DESCRIPTION
- also fixed the other usage of `redux-thunk`
- added `redux-localstorage` to vendor build

Fixes rangle/rangle-starter#60

can @SethDavenport review?