### PR TITLE
Fiddle with minification to reduce bundle size

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,8 +24,12 @@ const basePlugins = [
 const devPlugins = [];
 
 const prodPlugins = [
+  new webpack.optimize.OccurenceOrderPlugin(),
+  new webpack.optimize.DedupePlugin(),
   new webpack.optimize.UglifyJsPlugin({
-    mangle: false,
+    mangle: {
+       keep_fnames: true
+    },
     compress: {
       warnings: false
     }
@@ -39,23 +43,20 @@ const plugins = basePlugins
 module.exports = {
   entry: {
     app: './src/index.ts',
-    shims: './shims/shims_for_IE',
-    vendor: [
+    shims: [
       'es5-shim',
       'es6-shim',
       'es6-promise',
+      './shims/shims_for_IE'
+    ],
+    vendor: [
       'angular2/bundles/angular2-polyfills',
       'angular2/bootstrap',
       'angular2/platform/browser',
       'angular2/platform/common_dom',
       'angular2/core',
       'angular2/router',
-      'angular2/http',
-      'redux',
-      'redux-thunk',
-      'redux-localstorage',
-      'ng2-redux',
-      'redux-logger'
+      'angular2/http'
     ]
   },
 


### PR DESCRIPTION
... without breaking Angular.

Shaves off about 472 kB (a savings of 31.5%).

Fixes rangle/rangle-starter#73 as much as possible for now.  We need to keep an eye on Angular2 size, since that currently accounts for 679 kB of the remaining 1024 kB size.