### PR TITLE
Fix strange reload behaviour for source maps.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "clean": "rimraf dist/",
     "cover": "remap-istanbul -i coverage/chrome/coverage-final.json -o coverage/coverage.json",
     "postcover": "istanbul report lcov text-summary",
-    "dev": "cross-env NODE_ENV=development webpack-dev-server -d --inline --hot --progress --no-info",
+    "dev": "cross-env NODE_ENV=development webpack-dev-server -d --inline --progress --no-info",
     "lint": "tslint './src/**/*.ts'",
     "postinstall": "npm run typings && npm run build",
     "start": "cross-env NODE_ENV=production node server/node-server.js",

--- a/src/store/configure-store.ts
+++ b/src/store/configure-store.ts
@@ -14,7 +14,6 @@ function configureStore(initialState) {
     ..._getEnhancers()
   )(createStore)(rootReducer, initialState);
 
-  _enableHotLoader(store);
   return store;
 }
 
@@ -41,15 +40,6 @@ function _getEnhancers() {
   }
 
   return enhancers;
-}
-
-function _enableHotLoader(store) {
-  if (__DEV__ && module.hot) {
-    module.hot.accept('../reducers', () => {
-      const nextRootReducer = require('../reducers');
-      store.replaceReducer(nextRootReducer);
-    });
-  }
 }
 
 function _getStorageConfig() {

--- a/src/store/dev-types.d.ts
+++ b/src/store/dev-types.d.ts
@@ -7,9 +7,3 @@ declare let __DEV__: boolean;
 interface Window {
   devToolsExtension?: () => void;
 }
-
-// webpack-hot-loader sets some extra attributes on node's `module`if that
-// module has been hot-loaded in the browser.
-interface NodeModule {
-  hot: { accept: Function };
-}


### PR DESCRIPTION
Fixes rangle/rangle-starter#78

Hot reload doesn't work for Angular2, just React. But worse than that, it interferes with live-reloading of the typescript source maps.  This PR turns it off for this project.