### PR TITLE
added restartOnFileChange karma config flag to test:watch command

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "pretest": "rimraf coverage/ & npm run lint",
     "test": "karma start",
     "posttest": "npm run cover",
-    "test:watch": "karma start --singleRun false",
+    "test:watch": "karma start --singleRun false --restartOnFileChange true",
     "typings": "rimraf typings/ && typings install"
   },
   "repository": {


### PR DESCRIPTION
Since the tests can take a a while to run, I have often made changes before the tests have finished and then must wait a while before karma has a chance to re-run the tests. By turing _restartOnFileChange_ on, the current test run is terminated and a new one is started with the latest changes.

some documentation of the config flag https://github.com/karma-runner/karma/commit/1082f35