### PR TITLE
Add `cssnano` to end of `postcss` plugin chain to compress compiled `css` in prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "console-polyfill": "^0.2.2",
     "cross-env": "^1.0.7",
     "css-loader": "^0.23.1",
+    "cssnano": "^3.5.2",
     "es5-shim": "^4.5.6",
     "es6-promise": "^3.0.2",
     "es6-shim": "^0.35.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,6 +47,27 @@ const plugins = basePlugins
   .concat(process.env.NODE_ENV === 'production' ? prodPlugins : [])
   .concat(process.env.NODE_ENV === 'development' ? devPlugins : []);
 
+const postcssBasePlugins = [
+  require('postcss-import')({
+    addDependencyTo: webpack,
+  }),
+  require('postcss-cssnext')({
+    browsers: ['ie >= 8', 'last 2 versions'],
+  }),
+];
+const postcssDevPlugins = [];
+const postcssProdPlugins = [
+  require('cssnano')({
+    safe: true,
+    sourcemap: true,
+    autoprefixer:false,
+  }),
+];
+
+const postcssPlugins = postcssBasePlugins
+  .concat(process.env.NODE_ENV === 'production' ? postcssProdPlugins : [])
+  .concat(process.env.NODE_ENV === 'development' ? postcssDevPlugins : []);
+
 module.exports = {
   entry: {
     app: './src/index.ts',
@@ -102,14 +123,7 @@ module.exports = {
     noParse: [ /zone\.js\/dist\/.+/, /angular2\/bundles\/.+/ ]
   },
 
-  postcss: function() {
-    return [
-      require('postcss-import')({
-        addDependencyTo: webpack
-      }),
-      require('postcss-cssnext')({
-        browsers: ['ie >= 8', 'last 2 versions']
-      }),
-    ];
+  postcss: function postcssInit() {
+    return postcssPlugins;
   }
 };


### PR DESCRIPTION
Add `cssnano` to end of `postcss` plugin chain to compress compiled `css` when `NODE_ENV=production` only.

Split `postcss` plugins into an explicit `base` set concatenated with a `dev` or `prod` set to achieve this behaviour. This follows the pattern used by the general `webpack` plugins.

Connected to https://github.com/rangle/rangle-starter/issues/55