### PR TITLE
Fix: ApplicationRef.tick is called recursively

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,10 @@
+import 'es5-shim';
+import 'es6-shim';
+import 'es6-promise';
+import '../shims/shims_for_IE';
+
+import 'angular2/bundles/angular2-polyfills';
+
 import { enableProdMode, provide } from 'angular2/core';
 import { bootstrap } from 'angular2/platform/browser';
 import { ROUTER_PROVIDERS, APP_BASE_HREF } from 'angular2/router';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -74,13 +74,6 @@ const postcssPlugins = postcssBasePlugins
 module.exports = {
   entry: {
     app: './src/index.ts',
-    shims: [
-      'es5-shim',
-      'es6-shim',
-      'es6-promise',
-      './shims/shims_for_IE'
-    ],
-    ng2polyfills: 'angular2/bundles/angular2-polyfills',
   },
 
   output: {


### PR DESCRIPTION
Removed shims from webpack config and added explicit imports to index.ts to ensure the shims and angular2 polyfills load before angular does.  

Connected to rangle/rangle-starter#100