### PR TITLE
Adapt to official redux typings.

### DIFF
--- a/typings.json
+++ b/typings.json
@@ -6,8 +6,5 @@
     "immutable": "npm:immutable/dist/immutable.d.ts",
     "mocha": "github:DefinitelyTyped/DefinitelyTyped/mocha/mocha.d.ts#d6dd320291705694ba8e1a79497a908e9f5e6617",
     "node": "github:DefinitelyTyped/DefinitelyTyped/node/node.d.ts#366b936e62a6244a15f011e0ee0559b903d1dd65"
-  },
-  "dependencies": {
-    "redux-thunk": "registry:npm/redux-thunk#1.0.4+20160207154919"
   }
 }


### PR DESCRIPTION
Means that DT typings for a number of middlewares are now incorrect.

Connected to rangle/rangle-starter#41