### PR TITLE
Bug fix - in store, check if window.devToolsExtension exists before exporting it

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -19,6 +19,6 @@ const baseEnhancers = [
 
 export const middleware = __DEV__ ? [ logger ] : [];
 
-export const enhancers = __DEV__ ?
+export const enhancers = __DEV__ && window.devToolsExtension ?
   [ ...baseEnhancers, window.devToolsExtension() ] :
   baseEnhancers;


### PR DESCRIPTION
Connected to https://github.com/rangle/rangle-starter/issues/114

