### PR TITLE
Base href should be "/" instead of "." as specified in the Angular 2

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -6,7 +6,7 @@
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Rangle.io - Angular2 / Redux Seed</title>
-    <base href=".">
+    <base href="/">
   </head>
    <body>
     <div>


### PR DESCRIPTION
router docs.

Otherwise routes with route params are not recognized when entered
directly as URL in the browser.